### PR TITLE
feat(JsonSql): implicit string class to provide query interface

### DIFF
--- a/src/main/scala/com/mmalek/jsonSql/package.scala
+++ b/src/main/scala/com/mmalek/jsonSql/package.scala
@@ -7,7 +7,9 @@ import com.mmalek.jsonSql.sqlParsing.Token._
 import com.mmalek.jsonSql.sqlParsing.{Token, Tokenizer}
 
 package object jsonSql {
-  def runQuery(rawSql: String, rawJson: String): Either[String, Map[String, Seq[Option[JValue]]]] = {
+  type Result = Map[String, Seq[Option[JValue]]]]
+
+  def runQuery(rawSql: String, rawJson: String): Either[String, Result] = {
     val json = JsonParser.getJson(rawJson)
     val (tokens, error) = Tokenizer.tokenize(rawSql)
 
@@ -29,6 +31,13 @@ package object jsonSql {
             case Left(error) => Left(error)
           }
         } else Right(Map.empty[String, Seq[Option[JValue]]])
+    }
+  }
+
+  object implicits {
+    implicit class JsonSql(rawJson: String) {
+      def query(rawSql: String): Either[String, Result] =
+        runQuery(rawSql, rawJson)
     }
   }
 

--- a/src/test/scala/com/mmalek/jsonSql/ImplicitsTests.scala
+++ b/src/test/scala/com/mmalek/jsonSql/ImplicitsTests.scala
@@ -1,0 +1,17 @@
+package com.mmalek.jsonSql
+
+import com.mmalek.jsonSql.implicits._
+import com.mmalek.jsonSql.jsonParsing.dataStructures.{JNumber, JString}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class ImplicitsTests extends AnyFlatSpec with Matchers {
+  "A string" should "provide a query method when JsonSql is in scope" in {
+    val json = SampleJson.single
+    val Right(result) = json.query("""SELECT "id", "age", "fullname" FROM ##json## WHERE "id" = 1""")
+
+    result("id") should be(List(Some(JNumber(1))))
+    result("age") should be(List(Some(JNumber(1))))
+    result("fullname") should be(List(Some(JString("Raymond Mann"))))
+  }
+}


### PR DESCRIPTION
- adds `implicits` sub-object, with `JsonSql` string implicit
  - i.e. `"myJson...".query("my query....")`
- adds `ImplicitsTest` 
- adds helper type alias `Result` for `Right(...) = runQuery()`